### PR TITLE
Pixelpaint: Update debug message in the copy action to the used method

### DIFF
--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -189,7 +189,7 @@ int main(int argc, char** argv)
         }
         auto bitmap = editor->active_layer()->try_copy_bitmap(editor->selection());
         if (!bitmap) {
-            dbgln("try_copy() from Layer failed");
+            dbgln("try_copy_bitmap() from Layer failed");
             return;
         }
         GUI::Clipboard::the().set_bitmap(*bitmap);


### PR DESCRIPTION
This PR adjusts the debug message for the copy_action. The name of the function has changed from `try_copy` to `try_copy_bitmap` after the debug log message was written.